### PR TITLE
Zero Intervals/Durations have a valid Value()

### DIFF
--- a/duration_test.go
+++ b/duration_test.go
@@ -29,3 +29,13 @@ func TestDurationValue(t *testing.T) {
 		val,
 		"Duration.Value() compatibility with time.Duration")
 }
+
+func TestZeroDuration(t *testing.T) {
+	i := new(Duration)
+	assert.NoError(t, i.Scan("00:00:00"), "Duration.Scan() error")
+	assert.EqualValues(t, time.Duration(0), *i, "Duration.Scan() result")
+
+	val, err := i.Value()
+	assert.Nil(t, err, "Duration.Value() error")
+	assert.EqualValues(t, "0 microseconds", val, "Duration.Value() result")
+}

--- a/interval.go
+++ b/interval.go
@@ -133,7 +133,7 @@ func formatInput(years, months, days, hours, mins, secs, msecs, usecs int) strin
 	if msecs != 0 {
 		pieces = append(pieces, fmt.Sprintf("%d milliseconds", msecs))
 	}
-	if usecs != 0 {
+	if usecs != 0 || len(pieces) == 0 {
 		pieces = append(pieces, fmt.Sprintf("%d microseconds", usecs))
 	}
 	return strings.Join(pieces, " ")

--- a/interval_test.go
+++ b/interval_test.go
@@ -40,3 +40,15 @@ func TestIntervalValue(t *testing.T) {
 		val,
 		"Interval.Value() result")
 }
+
+func TestZeroInterval(t *testing.T) {
+	i := new(Interval)
+	assert.NoError(t, i.Scan("00:00:00"), "Interval.Scan() error")
+	assert.EqualValues(t, 0, i.Microseconds(), "Interval.Scan() result")
+	assert.EqualValues(t, 0, i.Hours(), "Interval.Scan() result")
+	assert.EqualValues(t, 0, i.Years(), "Interval.Scan() result")
+
+	val, err := i.Value()
+	assert.Nil(t, err, "Interval.Value() error")
+	assert.EqualValues(t, "0 microseconds", val, "Interval.Value() result")
+}


### PR DESCRIPTION
Zero-valued Durations and Intervals currently cannot be saved into a database, because Value() for these returns the empty string. 

This is a fix for this, together with tests.